### PR TITLE
Add NumPy to Requirements in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ specification.
 ## Requirements
 
 * Python 2 or Python 3
+* [NumPy](http://www.numpy.org)
 * One or more communication extensions
 
 ## Installation


### PR DESCRIPTION
[NumPy](http://www.numpy.org) is not listed in the Requirements section of the `README.md` file; however, I'm not able to perform `import ivi` unless I have NumPy installed. This pull request simply adds NumPy to the Requirements section so that users are aware of this requirement.
