### PR TITLE
Improved version checking.

### DIFF
--- a/ivi/interface/pyvisa.py
+++ b/ivi/interface/pyvisa.py
@@ -30,11 +30,11 @@ from distutils.version import StrictVersion
 
 try:
     import visa
-    if StrictVersion(visa.__version__) >= StrictVersion('1.6'):
+    try:
         # New style PyVISA
         visa_rm = visa.ResourceManager()
         visa_instrument_opener = visa_rm.open_resource
-    else:
+    except AttributeError:
         # Old style PyVISA
         visa_instrument_opener = visa.instrument
 except ImportError:


### PR DESCRIPTION
Version checking of pyvisa 1.9.dev0 fails because  'dev0' is not a valid ``StrictVersion``. So instead of checking the version number use the more pythonic way of trying to use the library unconditionally and if that fails use the fallback instead. 
Refs #28.