### PR TITLE
fix issue with too many arguments passed, using configure-function

### DIFF
--- a/ivi/dmm.py
+++ b/ivi/dmm.py
@@ -153,7 +153,7 @@ class Base(ivi.IviContainer):
         pass
     
     def _configure(self, function, range, resolution):
-        self._set_measurement_function(self, function)
+        self._set_measurement_function(function)
         if range in Auto:
             self._set_auto_range(range)
         else:


### PR DESCRIPTION
Got this:
>>> dmm.configure("dc_volts", 1.0, 1.0)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Python27\lib\site-packages\python_ivi-0.14.9-py2.7.egg\ivi\dmm.p
TypeError: _set_measurement_function() takes exactly 2 arguments (3 given)

Removing "self" from parameters fixes this issue.