### PR TITLE
fix some methods names

### DIFF
--- a/ivi/agilent/agilent436A.py
+++ b/ivi/agilent/agilent436A.py
@@ -73,7 +73,7 @@ class agilent436A(ivi.Driver, pwrmeter.Base, pwrmeter.ZeroCorrection, pwrmeter.M
         
         # reset
         if reset:
-            self.utility_reset()
+            self.utility.reset()
         
     
     def _load_id_string(self):

--- a/ivi/agilent/agilent437B.py
+++ b/ivi/agilent/agilent437B.py
@@ -76,7 +76,7 @@ class agilent437B(ivi.Driver, pwrmeter.Base, pwrmeter.ManualRange,
         
         # reset
         if reset:
-            self.utility_reset()
+            self.utility.reset()
         
     
     def _load_id_string(self):

--- a/ivi/agilent/agilent603xA.py
+++ b/ivi/agilent/agilent603xA.py
@@ -85,7 +85,7 @@ class agilent603xA(ivi.Driver, dcpwr.Base, dcpwr.Measurement):
         
         # reset
         if reset:
-            self.utility_reset()
+            self.utility.reset()
         
     
     def _load_id_string(self):

--- a/ivi/agilent/agilent8156A.py
+++ b/ivi/agilent/agilent8156A.py
@@ -100,7 +100,7 @@ class agilent8156A(ivi.Driver):
 
         # reset
         if reset:
-            self.utility_reset()
+            self.utility.reset()
 
 
     def _load_id_string(self):

--- a/ivi/agilent/agilent85644A.py
+++ b/ivi/agilent/agilent85644A.py
@@ -159,7 +159,7 @@ class agilent85644A(ivi.Driver, scpi.common.Memory):
 
         # reset
         if reset:
-            self.utility_reset()
+            self.utility.reset()
 
 
     def _load_id_string(self):

--- a/ivi/agilent/agilent86140B.py
+++ b/ivi/agilent/agilent86140B.py
@@ -378,7 +378,7 @@ class agilent86140B(ivi.Driver, extra.common.Screenshot, scpi.common.Memory):
         
         # reset
         if reset:
-            self.utility_reset()
+            self.utility.reset()
         
     
     def _load_id_string(self):

--- a/ivi/agilent/agilent8642A.py
+++ b/ivi/agilent/agilent8642A.py
@@ -194,7 +194,7 @@ class agilent8642A(ivi.Driver, rfsiggen.Base, rfsiggen.ModulateAM,
         
         # reset
         if reset:
-            self.utility_reset()
+            self.utility.reset()
         
     
     def _get_identity_instrument_manufacturer(self):

--- a/ivi/agilent/agilentBase8340.py
+++ b/ivi/agilent/agilentBase8340.py
@@ -82,7 +82,7 @@ class agilentBase8340(rfsiggen.Base, rfsiggen.ModulateAM, rfsiggen.ModulateFM,
 
         # reset
         if reset:
-            self.utility_reset()
+            self.utility.reset()
 
 
     def _get_identity_instrument_manufacturer(self):

--- a/ivi/agilent/agilentBaseESG.py
+++ b/ivi/agilent/agilentBaseESG.py
@@ -124,7 +124,7 @@ class agilentBaseESG(scpi.common.IdnCommand, scpi.common.ErrorQuery, scpi.common
 
         # reset
         if reset:
-            self.utility_reset()
+            self.utility.reset()
 
 
     def _utility_disable(self):

--- a/ivi/agilent/agilentE3600A.py
+++ b/ivi/agilent/agilentE3600A.py
@@ -143,7 +143,7 @@ class agilentE3600A(scpi.dcpwr.Base, scpi.dcpwr.Trigger, scpi.dcpwr.SoftwareTrig
         
         # reset
         if reset:
-            self.utility_reset()
+            self.utility.reset()
         
     
     def _get_couple_tracking_enabled(self):

--- a/ivi/agilent/agilentU2000.py
+++ b/ivi/agilent/agilentU2000.py
@@ -86,7 +86,7 @@ class agilentU2000(scpi.common.IdnCommand, scpi.common.ErrorQuery,
         
         # reset
         if reset:
-            self.utility_reset()
+            self.utility.reset()
         
     
     def _utility_disable(self):

--- a/ivi/agilent/agilentU2722A.py
+++ b/ivi/agilent/agilentU2722A.py
@@ -106,7 +106,7 @@ class agilentU2722A(scpi.common.IdnCommand, scpi.common.ErrorQuery, scpi.common.
 
         # reset
         if reset:
-            self.utility_reset()
+            self.utility.reset()
 
     def _utility_disable(self):
         pass

--- a/ivi/colby/colbyPDL10A.py
+++ b/ivi/colby/colbyPDL10A.py
@@ -89,7 +89,7 @@ class colbyPDL10A(scpi.common.IdnCommand, scpi.common.Reset,
 
         # reset
         if reset:
-            self.utility_reset()
+            self.utility.reset()
 
 
     def _utility_disable(self):

--- a/ivi/dicon/diconGP700.py
+++ b/ivi/dicon/diconGP700.py
@@ -209,7 +209,7 @@ class diconGP700(scpi.common.IdnCommand, scpi.common.ErrorQuery, scpi.common.Res
         
         # reset
         if reset:
-            self.utility_reset()
+            self.utility.reset()
         
         if not self._initialized_from_constructor:
             self._init_channels()

--- a/ivi/ics/ics8099.py
+++ b/ivi/ics/ics8099.py
@@ -75,7 +75,7 @@ class ics8099(scpi.common.IdnCommand, scpi.common.Reset,
 
         # reset
         if reset:
-            self.utility_reset()
+            self.utility.reset()
 
 
     def _utility_disable(self):

--- a/ivi/ivi.py
+++ b/ivi/ivi.py
@@ -1558,7 +1558,7 @@ class DriverUtility(IviContainer):
         pass
     
     def _utility_reset_with_defaults(self):
-        self.utility_reset()
+        self.utility.reset()
     
     def _utility_self_test(self):
         code = 0

--- a/ivi/jdsu/jdsuTB9.py
+++ b/ivi/jdsu/jdsuTB9.py
@@ -83,7 +83,7 @@ class jdsuTB9(ivi.Driver):
 
         # reset
         if reset:
-            self.utility_reset()
+            self.utility.reset()
 
 
     def _load_id_string(self):

--- a/ivi/pwrmeter.py
+++ b/ivi/pwrmeter.py
@@ -395,7 +395,7 @@ class SoftwareTrigger(ivi.IviContainer):
         grp = 'SoftwareTrigger'
         ivi.add_group_capability(self, cls+grp)
     
-    def send_software_trigger(self):
+    def _send_software_trigger(self):
         pass
     
     

--- a/ivi/scpi/dcpwr.py
+++ b/ivi/scpi/dcpwr.py
@@ -98,7 +98,7 @@ class Base(common.IdnCommand, common.ErrorQuery, common.Reset, common.SelfTest,
 
         # reset
         if reset:
-            self.utility_reset()
+            self.utility.reset()
 
     def _get_bool_str(self, value):
         """

--- a/ivi/tektronix/tektronixAM5030.py
+++ b/ivi/tektronix/tektronixAM5030.py
@@ -162,7 +162,7 @@ class tektronixAM5030(ivi.Driver):
 
         # reset
         if reset:
-            self.utility_reset()
+            self.utility.reset()
 
 
     def _load_id_string(self):

--- a/ivi/tektronix/tektronixAWG2000.py
+++ b/ivi/tektronix/tektronixAWG2000.py
@@ -547,7 +547,7 @@ class tektronixAWG2000(ivi.Driver, fgen.Base, fgen.StdFunc, fgen.ArbWfm,
     def _arbitrary_sequence_create(self, handle_list, loop_count_list):
         return "handle"
     
-    def send_software_trigger(self):
+    def _send_software_trigger(self):
         if not self._driver_operation_simulate:
             self._write("*TRG")
     

--- a/ivi/tektronix/tektronixAWG2000.py
+++ b/ivi/tektronix/tektronixAWG2000.py
@@ -100,7 +100,7 @@ class tektronixAWG2000(ivi.Driver, fgen.Base, fgen.StdFunc, fgen.ArbWfm,
         
         # reset
         if reset:
-            self.utility_reset()
+            self.utility.reset()
         
     
     def _load_id_string(self):

--- a/ivi/tektronix/tektronixOA5000.py
+++ b/ivi/tektronix/tektronixOA5000.py
@@ -101,7 +101,7 @@ class tektronixOA5000(ivi.Driver):
 
         # reset
         if reset:
-            self.utility_reset()
+            self.utility.reset()
 
 
     def _load_id_string(self):


### PR DESCRIPTION
In some modules (not all) the following method call and definition, respectively, is already correct:
- self.utility_reset() --> self.utility.reset()
- def send_software_trigger(self) --> def _send_software_trigger(self)
