### PR TITLE
Fix a typo in agilentE4434B.py (a copy-paste artifact?)

### DIFF
--- a/ivi/agilent/agilentE4435B.py
+++ b/ivi/agilent/agilentE4435B.py
@@ -32,7 +32,7 @@ class agilentE4435B(agilentBaseESGD):
     def __init__(self, *args, **kwargs):
         self.__dict__.setdefault('_instrument_id', 'ESG-D4000B')
 
-        super(agilentE4434B, self).__init__(*args, **kwargs)
+        super(agilentE4435B, self).__init__(*args, **kwargs)
 
         self._frequency_low = 250e3
         self._frequency_high = 2e9


### PR DESCRIPTION
This patch fixed the problem which can be best demonstrated with the following snippet:
```
>>> import ivi
>>> a = ivi.agilent.agilentE4435B()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/<...>/ivi/agilent/agilentE4435B.py", line 35, in __init__
    super(agilentE4434B, self).__init__(*args, **kwargs)
NameError: name 'agilentE4434B' is not defined
```

That seems to be the same issue as #8 and #55. Copy & paste is a dangerous development methodology, isn't it a good idea to replace all the wrapper classed with something saner or at least add a unit test to ensure that all devices can default construct?