### PR TITLE
Renamed lecroyWRXIA to lecroyXStream.

### DIFF
--- a/ivi/lecroy/lecroyWR104MXIA.py
+++ b/ivi/lecroy/lecroyWR104MXIA.py
@@ -24,9 +24,9 @@ THE SOFTWARE.
 
 """
 
-from .lecroyWRXIA import *
+from .lecroyXStream import *
 
-class lecroyWR104MXIA(lecroyWRXIA):
+class lecroyWR104MXIA(lecroyXStream):
     "Lecroy WaveRunner 104MXi-A IVI oscilloscope driver"
 
     def __init__(self, *args, **kwargs):

--- a/ivi/lecroy/lecroyWR104XIA.py
+++ b/ivi/lecroy/lecroyWR104XIA.py
@@ -24,9 +24,9 @@ THE SOFTWARE.
 
 """
 
-from .lecroyWRXIA import *
+from .lecroyXStream import *
 
-class lecroyWR104XIA(lecroyWRXIA):
+class lecroyWR104XIA(lecroyXStream):
     "Lecroy WaveRunner 104Xi-A IVI oscilloscope driver"
 
     def __init__(self, *args, **kwargs):

--- a/ivi/lecroy/lecroyWR204MXIA.py
+++ b/ivi/lecroy/lecroyWR204MXIA.py
@@ -24,9 +24,9 @@ THE SOFTWARE.
 
 """
 
-from .lecroyWRXIA import *
+from .lecroyXStream import *
 
-class lecroyWR204MXIA(lecroyWRXIA):
+class lecroyWR204MXIA(lecroyXStream):
     "Lecroy WaveRunner 204MXi-A IVI oscilloscope driver"
 
     def __init__(self, *args, **kwargs):

--- a/ivi/lecroy/lecroyWR204XIA.py
+++ b/ivi/lecroy/lecroyWR204XIA.py
@@ -24,9 +24,9 @@ THE SOFTWARE.
 
 """
 
-from .lecroyWRXIA import *
+from .lecroyXStream import *
 
-class lecroyWR204XIA(lecroyWRXIA):
+class lecroyWR204XIA(lecroyXStream):
     "Lecroy WaveRunner 204Xi-A IVI oscilloscope driver"
 
     def __init__(self, *args, **kwargs):

--- a/ivi/lecroy/lecroyWR44MXIA.py
+++ b/ivi/lecroy/lecroyWR44MXIA.py
@@ -24,9 +24,9 @@ THE SOFTWARE.
 
 """
 
-from .lecroyWRXIA import *
+from .lecroyXStream import *
 
-class lecroyWR44MXIA(lecroyWRXIA):
+class lecroyWR44MXIA(lecroyXStream):
     "Lecroy WaveRunner 44MXi-A IVI oscilloscope driver"
 
     def __init__(self, *args, **kwargs):

--- a/ivi/lecroy/lecroyWR44XIA.py
+++ b/ivi/lecroy/lecroyWR44XIA.py
@@ -24,9 +24,9 @@ THE SOFTWARE.
 
 """
 
-from .lecroyWRXIA import *
+from .lecroyXStream import *
 
-class lecroyWR44XIA(lecroyWRXIA):
+class lecroyWR44XIA(lecroyXStream):
     "Lecroy WaveRunner 44Xi-A IVI oscilloscope driver"
 
     def __init__(self, *args, **kwargs):

--- a/ivi/lecroy/lecroyWR62XIA.py
+++ b/ivi/lecroy/lecroyWR62XIA.py
@@ -24,9 +24,9 @@ THE SOFTWARE.
 
 """
 
-from .lecroyWRXIA import *
+from .lecroyXStream import *
 
-class lecroyWR62XIA(lecroyWRXIA):
+class lecroyWR62XIA(lecroyXStream):
     "Lecroy WaveRunner 62Xi-A IVI oscilloscope driver"
 
     def __init__(self, *args, **kwargs):

--- a/ivi/lecroy/lecroyWR64MXIA.py
+++ b/ivi/lecroy/lecroyWR64MXIA.py
@@ -24,9 +24,9 @@ THE SOFTWARE.
 
 """
 
-from .lecroyWRXIA import *
+from .lecroyXStream import *
 
-class lecroyWR64MXIA(lecroyWRXIA):
+class lecroyWR64MXIA(lecroyXStream):
     "Lecroy WaveRunner 64MXi-A IVI oscilloscope driver"
 
     def __init__(self, *args, **kwargs):

--- a/ivi/lecroy/lecroyWR64XIA.py
+++ b/ivi/lecroy/lecroyWR64XIA.py
@@ -24,9 +24,9 @@ THE SOFTWARE.
 
 """
 
-from .lecroyWRXIA import *
+from .lecroyXStream import *
 
-class lecroyWR64XIA(lecroyWRXIA):
+class lecroyWR64XIA(lecroyXStream):
     "Lecroy WaveRunner 64Xi-A IVI oscilloscope driver"
 
     def __init__(self, *args, **kwargs):

--- a/ivi/lecroy/lecroyXStream.py
+++ b/ivi/lecroy/lecroyXStream.py
@@ -54,13 +54,13 @@ TriggerTypes = set(['dropout', 'edge', 'glitch', 'interval', 'logic', 'qualify',
 ExtTriggerSetting = set(["Ext", "ExtDivide10", "Line"])
 VerticalCoupling = set(['ac', 'dc', 'gnd'])
 
-class lecroyWRXIA(lecroyBaseScope):
-    """LeCroy WaveRunner Xi-A / MXi-A series IVI oscilloscope driver"""
+class lecroyXStream(lecroyBaseScope):
+    """LeCroy X-Stream IVI oscilloscope driver"""
 
     def __init__(self, *args, **kwargs):
         self.__dict__.setdefault('_instrument_id', '')
 
-        super(lecroyWRXIA, self).__init__(*args, **kwargs)
+        super(lecroyXStream, self).__init__(*args, **kwargs)
 
         self._channel_interpolation = list()
         self._analog_channel_name = list()
@@ -74,9 +74,9 @@ class lecroyWRXIA(lecroyBaseScope):
 
         self._memory_size = 5
 
-        self._identity_description = "LeCroy WaveRunner Xi-A / MXi-A series IVI oscilloscope driver"
+        self._identity_description = "LeCroy X-Stream IVI oscilloscope driver"
         self._identity_supported_instrument_models = ['WR204MXI-A', 'WR204XI-A', 'WR104MXI-A', 'WR104XI-A', 'WR64MXI-A',
-                                                      'WR64XI-A', 'WR62XI-A', 'WR44MXI-A', 'WR44XI-A']
+                                                      'WR64XI-A', 'WR62XI-A', 'WR44MXI-A', 'WR44XI-A', 'WRHRO66Zi']
 
         ivi.add_property(self, 'channels[].noise_filter',
                          self._get_channel_noise_filter,

--- a/ivi/lecroy/lecroyXStream.py
+++ b/ivi/lecroy/lecroyXStream.py
@@ -76,7 +76,7 @@ class lecroyXStream(lecroyBaseScope):
 
         self._identity_description = "LeCroy X-Stream IVI oscilloscope driver"
         self._identity_supported_instrument_models = ['WR204MXI-A', 'WR204XI-A', 'WR104MXI-A', 'WR104XI-A', 'WR64MXI-A',
-                                                      'WR64XI-A', 'WR62XI-A', 'WR44MXI-A', 'WR44XI-A', 'WRHRO66Zi']
+                                                      'WR64XI-A', 'WR62XI-A', 'WR44MXI-A', 'WR44XI-A']
 
         ivi.add_property(self, 'channels[].noise_filter',
                          self._get_channel_noise_filter,


### PR DESCRIPTION
All Lecroy X-Stream scopes support the same VBS command so they should be compatible.

I want to add support for the "Lecroy WaveRunner HRO 66 Zi". Because I don't want to copy the whole `lecroyWRXIA.py` file I renamed it and all references to `lecroyXStream`.

I already wrote and tested the "Lecroy WaveRunner HRO 66 Zi" driver. The pull request will follow as soon as this one is merged.