### PR TITLE
fix util.compat.Directive deprecated

### DIFF
--- a/doc/exec.py
+++ b/doc/exec.py
@@ -6,7 +6,7 @@ try:
 except ImportError:
     from io import StringIO
 
-from sphinx.util.compat import Directive
+from docutils.parsers.rst import Directive
 from docutils import nodes, statemachine
 
 class ExecDirective(Directive):


### PR DESCRIPTION
Documentation wasn't compiling, so I fixed the issue